### PR TITLE
Preserve the precision of DateTime, i.e., milliseconds

### DIFF
--- a/lib/format_value.dart
+++ b/lib/format_value.dart
@@ -99,9 +99,16 @@ _formatDateTime(DateTime datetime, String type) {
       ..write(':')
       ..write(pad(datetime.minute))
       ..write(':')
-      ..write(pad(datetime.second))
-      ..write('.')
-      ..write(datetime.millisecond);
+      ..write(pad(datetime.second));
+
+    final int ms = datetime.millisecond;
+    if (ms != 0) {
+      sb.write('.');
+      final s = ms.toString();
+      if (s.length == 1) sb.write('00');
+      else if (s.length == 2) sb.write('0');
+      sb.write(s);
+    }
   }
 
   if (t == 'timestamptz') {

--- a/test/postgresql_test.dart
+++ b/test/postgresql_test.dart
@@ -277,14 +277,14 @@ main() {
       );
     });
 
-    test('Select timestamp', () {
-
+    test('Select timestamp with milliseconds', () {
+      final DateTime time = new DateTime(1979, 12, 20, 9, 0, 12);
       conn.execute('create temporary table dart_unit_test (a timestamp)');
-      conn.execute("insert into dart_unit_test values ('1979-12-20 09:00')");
+      conn.execute("insert into dart_unit_test values (@time)", {"time": time});
 
       conn.query('select a from dart_unit_test').toList().then(
         expectAsync1((rows) {
-          expect(rows[0][0], equals(new DateTime(1979, 12, 20, 9)));
+          expect(rows[0][0], equals(time));
         })
       );
     });


### PR DESCRIPTION
It is better to preserve the resolution of Dart DateTime, such that the value being read back will be the same as the original value.
