### PR TITLE
Different handling of DateTime conversion

### DIFF
--- a/lib/src/postgresql_impl/connection.dart
+++ b/lib/src/postgresql_impl/connection.dart
@@ -495,6 +495,7 @@ class ConnectionImpl implements Connection {
     try {
       if (values != null)
         sql = substitute(sql, values, _typeConverter.encode);
+
       var query = _enqueueQuery(sql);
       return query.stream.isEmpty.then((_) => query._rowsAffected);
     } on Exception catch (ex, st) {

--- a/lib/src/postgresql_impl/type_converter.dart
+++ b/lib/src/postgresql_impl/type_converter.dart
@@ -191,6 +191,7 @@ class DefaultTypeConverter implements TypeConverter {
       return 'null';
 
     var string = datetime.toIso8601String();
+
     if(isDateOnly) {
       string = string.split("T").first;
     } else {
@@ -272,6 +273,11 @@ class DefaultTypeConverter implements TypeConverter {
   }
 
   DateTime decodeDateTime(String value, int pgType, {bool isUtcTimeZone, getConnectionName()}) {
+    // Built in Dart dates can either be local time or utc. Which means that the
+    // the postgresql timezone parameter for the connection must be either set
+    // to UTC, or the local time of the server on which the client is running.
+    // This restriction could be relaxed by using a more advanced date library
+    // capable of creating DateTimes for a non-local time zone.
 
     if (value == 'infinity' || value == '-infinity') {
       throw _error('Server returned a timestamp with value '

--- a/lib/src/postgresql_impl/type_converter.dart
+++ b/lib/src/postgresql_impl/type_converter.dart
@@ -191,8 +191,14 @@ class DefaultTypeConverter implements TypeConverter {
       return 'null';
 
     var timezoneString = (datetime.isUtc ? "" : datetime.timeZoneName);
+    var string = datetime.toIso8601String();
+    if(isDateOnly) {
+      string = string.split("T").first;
+    } else {
+      string = string + timezoneString;
+    }
 
-    return "'${datetime.toIso8601String()}${timezoneString}'";
+    return "'${string}'";
   }
   
   // See http://www.postgresql.org/docs/9.0/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,5 @@ environment:
 dependencies:
   crypto: ">=0.9.0 <0.10.0"
 dev_dependencies:
-  unittest: ">=0.9.0 <0.12.0"
+  test: ">=0.12.0 <0.13.0"
   yaml: ">=0.9.0 <3.0.0"
-  matcher: ">=0.11.1 <0.12.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.3.1+1
+version: 0.3.2
 author: Greg Lowe <greg@vis.net.nz>
 description: Postgresql database driver.
 homepage: https://github.com/xxgreg/dart_postgresql

--- a/test/buffer_test.dart
+++ b/test/buffer_test.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:postgresql/src/buffer.dart';
 
 smiles(int i) {

--- a/test/postgresql_mock_test.dart
+++ b/test/postgresql_mock_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:postgresql/postgresql.dart';
 import 'package:postgresql/src/mock/mock.dart';
 import 'package:postgresql/src/protocol.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 
 main() {

--- a/test/postgresql_mock_test_cps.dart
+++ b/test/postgresql_mock_test_cps.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:postgresql/postgresql.dart';
 import 'package:postgresql/src/mock/mock.dart';
 import 'package:postgresql/src/protocol.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 
 main() {

--- a/test/postgresql_pool_test.dart
+++ b/test/postgresql_pool_test.dart
@@ -4,7 +4,7 @@ import 'package:postgresql/pool.dart';
 import 'package:postgresql/postgresql.dart';
 import 'package:postgresql/src/mock/mock.dart';
 import 'package:postgresql/src/pool_impl_cps.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 
 //_log(msg) => print(msg);

--- a/test/postgresql_pool_test_cps.dart
+++ b/test/postgresql_pool_test_cps.dart
@@ -4,7 +4,7 @@ import 'package:postgresql/pool.dart';
 import 'package:postgresql/postgresql.dart';
 import 'package:postgresql/src/mock/mock.dart';
 import 'package:postgresql/src/pool_impl_cps.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 
 //_log(msg) => print(msg);

--- a/test/postgresql_test.dart
+++ b/test/postgresql_test.dart
@@ -395,6 +395,21 @@ main() {
       );
     });
 
+    /*
+    These tests will handle timestamps outside of the explicitly supported ISO8601 range.
+
+    test("DateTime Edge Cases", () {
+      conn.execute('create temporary table dart_unit_test (a timestamp)');
+      conn.execute("insert into dart_unit_test (a) values (@t)", {"t" : new DateTime(10000).toUtc()});
+      conn.execute("insert into dart_unit_test (a) values (@t)", {"t" : new DateTime(-10).toUtc()});
+
+      conn.query("select a from dart_unit_test").toList().then(expectAsync((rows) {
+        expect((rows[0][0] as DateTime).difference(new DateTime(10000).toUtc()), Duration.ZERO);
+        expect((rows[1][0] as DateTime).difference(new DateTime(-10).toUtc()), Duration.ZERO);
+      }));
+    });
+    */
+
     test('Select double', () {
 
       conn.execute('create temporary table dart_unit_test (a float4, b float8)');

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import 'package:postgresql/pool.dart';
 import 'package:postgresql/postgresql.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
 Settings loadSettings(){

--- a/test/substitute_test.dart
+++ b/test/substitute_test.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:postgresql/postgresql.dart';
 import 'package:postgresql/src/postgresql_impl/postgresql_impl.dart';
 import 'package:postgresql/src/substitute.dart';

--- a/test/type_converter_test.dart
+++ b/test/type_converter_test.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:postgresql/postgresql.dart';
 import 'package:postgresql/src/postgresql_impl/postgresql_impl.dart';
 import 'package:yaml/yaml.dart';
@@ -49,34 +49,30 @@ main() {
 
   test('encode datetime', () {
     var data = [
-      "22001-02-03 00:00:00.000",    new DateTime(22001, DateTime.FEBRUARY, 3),
-      "2001-02-03 00:00:00.000",     new DateTime(2001, DateTime.FEBRUARY, 3),
-      "2001-02-03 04:05:06.000",     new DateTime(2001, DateTime.FEBRUARY, 3, 4, 5, 6, 0),
-      "2001-02-03 04:05:06.999",     new DateTime(2001, DateTime.FEBRUARY, 3, 4, 5, 6, 999),
-      "0010-02-03 04:05:06.123 BC",  new DateTime(-10, DateTime.FEBRUARY, 3, 4, 5, 6, 123),
-      "0010-02-03 04:05:06.000 BC",      new DateTime(-10, DateTime.FEBRUARY, 3, 4, 5, 6, 0)
+      "2001-02-03T00:00:00.000",     new DateTime(2001, DateTime.FEBRUARY, 3),
+      "2001-02-03T04:05:06.000",     new DateTime(2001, DateTime.FEBRUARY, 3, 4, 5, 6, 0),
+      "2001-02-03T04:05:06.999",     new DateTime(2001, DateTime.FEBRUARY, 3, 4, 5, 6, 999),
+      "-0010-02-03T04:05:06.123",  new DateTime(-10, DateTime.FEBRUARY, 3, 4, 5, 6, 123),
+      "-0010-02-03T04:05:06.000",      new DateTime(-10, DateTime.FEBRUARY, 3, 4, 5, 6, 0)
       //TODO test minimum allowable postgresql date
     ];
     var tc = new TypeConverter();
-    var d = new DateTime.now().timeZoneOffset; // Get users current timezone
-    pad(int i) => i.toString().padLeft(2, '0');
-    var tzoff = '${d.isNegative ? '-' : '+'}'
-      '${d.inHours}:${pad(d.inMinutes % 60)}:${pad(d.inSeconds % 60)}';
+    var d = new DateTime(2001).timeZoneName; // Get users current timezone
+
     for (int i = 0; i < data.length; i += 2) {
       var str = data[i];
       var dt = data[i + 1];
-      expect(tc.encode(dt, null), equals("'$str $tzoff'"));
+      expect(tc.encode(dt, null), equals("'$str$d'"));
     }
   });
 
   test('encode date', () {
     var data = [
-      "22001-02-03",    new DateTime(22001, DateTime.FEBRUARY, 3),
       "2001-02-03",     new DateTime(2001, DateTime.FEBRUARY, 3),
       "2001-02-03",     new DateTime(2001, DateTime.FEBRUARY, 3, 4, 5, 6, 0),
       "2001-02-03",     new DateTime(2001, DateTime.FEBRUARY, 3, 4, 5, 6, 999),
-      "0010-02-03 BC",  new DateTime(-10, DateTime.FEBRUARY, 3, 4, 5, 6, 123),
-      "0010-02-03 BC",  new DateTime(-10, DateTime.FEBRUARY, 3, 4, 5, 6, 0)
+      "-0010-02-03",  new DateTime(-10, DateTime.FEBRUARY, 3, 4, 5, 6, 123),
+      "-0010-02-03",  new DateTime(-10, DateTime.FEBRUARY, 3, 4, 5, 6, 0)
     ];
     var tc = new TypeConverter();
     for (int i = 0; i < data.length; i += 2) {
@@ -151,7 +147,7 @@ main() {
     expect(tc.encode(1, 'String'), equals(" E'1' "));
 
     expect(tc.encode(new DateTime.utc(1979,12,20,9), 'date'), equals("'1979-12-20'"));
-    expect(tc.encode(new DateTime.utc(1979,12,20,9), 'timestamp'), equals("'1979-12-20 09:00:00.000 UTC'"));
+    expect(tc.encode(new DateTime.utc(1979,12,20,9), 'timestamp'), equals("'1979-12-20T09:00:00.000Z'"));
   });
 
   


### PR DESCRIPTION
The main purpose of this pull request is to use the ISO8601 standard for encoding and decoding DateTime instances. It also fixes the issue where fractional seconds are discarded when decoding a timestamp/timestamptz. When working with a timestamp column, a user of this library should first convert a DateTime instance to UTC. When working with a timestamptz column, a user may use a DateTime instance in local time.

Additional details: The version number has been changed to 0.3.2. The unit test package has been changed to the renamed 'test' package.