### PR TITLE
Fix #69: Empty connection pool not establishing connections

### DIFF
--- a/lib/src/pool_impl.dart
+++ b/lib/src/pool_impl.dart
@@ -374,6 +374,7 @@ class PoolImpl implements Pool {
       var c = new Completer<PooledConnectionImpl>();
       _waitQueue.add(c);
       try {
+        _processWaitQueue();
         pconn = await c.future.timeout(timeout, onTimeout: () => throw timeoutException());
       } finally {
         _waitQueue.remove(c);

--- a/test/postgresql_pool_test.dart
+++ b/test/postgresql_pool_test.dart
@@ -17,6 +17,7 @@ main() {
   test('Test start timeout', testStartTimeout);
   test('Test connect timeout', testConnectTimeout);
   test('Test wait queue', testWaitQueue);
+  test('Test empty pool', testEmptyPool);
 }
 
 PoolImpl createPool(PoolSettings settings) {
@@ -178,4 +179,27 @@ Future testWaitQueue() async {
   c3.close();
 
   
+}
+
+
+Future testEmptyPool() async {
+var settings = new PoolSettings(
+    databaseUri: 'postgresql://fakeuri',
+    minConnections: 0,
+    maxConnections: 2);
+
+    var pool = createPool(settings);
+
+    expect(pool.connections, isEmpty);
+
+    var v = await pool.start();
+
+    expect(v, isNull);
+    expect(pool.connections.length, equals(0));
+
+    var c1 = await pool.connect();
+
+    expect(c1.state, equals(idle));
+
+    c1.close();
 }


### PR DESCRIPTION
The waiting queue was only processed by the heartbeat timer and when closing another connection.

My proposal is to call waiting queue whenever a connection is requested. This also removes the problem that connection requests would have to wait 1 second (in the worst case) for the heartbeat to establish the connection.