### PR TITLE
Implement LISTEN support

### DIFF
--- a/lib/postgresql.dart
+++ b/lib/postgresql.dart
@@ -103,6 +103,9 @@ abstract class Connection {
   /// This will never throw an exception.
   void close();
 
+  /// Listen to messages send via NOTIFY to [channel].
+  Stream<String> listen(String channel);
+
   /// The server can send errors and notices, or the network can cause errors
   /// while the connection is not being used to make a query. These can be 
   /// caught by listening to the messages stream. See [ClientMessage] and 

--- a/lib/src/mock/mock.dart
+++ b/lib/src/mock/mock.dart
@@ -138,6 +138,10 @@ class MockConnection implements pg.Connection {
   Future runInTransaction(Future operation(), [pg.Isolation isolation])
     => throw new UnimplementedError();
 
+  @override
+  Stream<String> listen(String channel) {
+    throw new UnimplementedError();
+  }
 }
 
 

--- a/lib/src/pool_impl.dart
+++ b/lib/src/pool_impl.dart
@@ -84,6 +84,11 @@ class ConnectionDecorator implements pg.Connection {
 
   @override
   String toString() => "$_pconn";
+
+  @override
+  Stream<String> listen(String channel) {
+    throw new UnsupportedError('LISTEN isn\'t supported for pool connections');
+  }
 }
 
 


### PR DESCRIPTION
A possible fix for #62.

Usage:
```
   import 'package:postgresql/postgresql.dart';
   
   main() async {
     var uri = 'postgres://test:test@localhost:5432/test';
     var connection = await connect(uri);
   
     final stream = connection.listen('test');
   
     var sub;
     sub = stream.listen((e) {
       print('$e');
   
       if (e == 'quit') {
         sub.cancel();
         connection.close();
       }
     });
```